### PR TITLE
Feat/add bloom filter

### DIFF
--- a/bloom_filter/filter.go
+++ b/bloom_filter/filter.go
@@ -1,0 +1,48 @@
+package bloomfilter
+
+import (
+	"github.com/cespare/xxhash/v2"
+	"github.com/hasssanezzz/goldb-engine/shared"
+)
+
+type BloomFilter struct {
+	bitset  []bool
+	size    uint64
+	digests []*xxhash.Digest
+}
+
+func New() *BloomFilter {
+	digests := make([]*xxhash.Digest, shared.HashFunctionsNumber)
+	for i := 0; i < 7; i++ {
+		digests[i] = xxhash.NewWithSeed(uint64(i))
+	}
+
+	return &BloomFilter{
+		bitset:  make([]bool, shared.BloomFilterSize),
+		size:    shared.BloomFilterSize,
+		digests: digests,
+	}
+}
+
+func (bf *BloomFilter) Add(key string) {
+	for i := 0; i < 7; i++ {
+		bf.digests[i].ResetWithSeed(uint64(i))
+		bf.digests[i].Write([]byte(key))
+		bf.bitset[bf.digests[i].Sum64()%bf.size] = true
+	}
+}
+
+func (bf *BloomFilter) PossiblyContains(key string) bool {
+	for i := 0; i < 7; i++ {
+		bf.digests[i].ResetWithSeed(uint64(i))
+		bf.digests[i].Write([]byte(key))
+		if !bf.bitset[bf.digests[i].Sum64()%bf.size] {
+			return false
+		}
+	}
+	return true
+}
+
+func (bf *BloomFilter) Reset() {
+	bf.bitset = make([]bool, bf.size)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -152,7 +152,7 @@ func (e *Engine) Set(key string, value []byte, ignoreWAL ...bool) error {
 	if err != nil {
 		return fmt.Errorf("db engine can not write (%q, %x): %v", key, value, err)
 	}
-	e.indexManager.Memtable.Set(key, memtable.IndexNode{
+	e.indexManager.Set(key, memtable.IndexNode{
 		Offset: offset,
 		Size:   uint32(len(value)),
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/hasssanezzz/goldb-engine
 
 go 1.22.2
+
+require github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/shared/constants.go
+++ b/shared/constants.go
@@ -6,6 +6,8 @@ const KeyByteLength = 256
 const MetadataSize = KeyByteLength*2 + 4*2
 const KVPairSize = KeyByteLength + 4*2
 const MemtableSizeThreshold = 119_155 // about 30MB
+const HashFunctionsNumber = 7
+const BloomFilterSize = 1 << 21
 const SSTableExpectedSize = MetadataSize + MemtableSizeThreshold*KVPairSize
 
 type ErrKeyTooLong struct{ Key string }


### PR DESCRIPTION
## What

Add a Bloom filter as an external layer to optimize key existence checks before searching the memtable.

## How 

* The bitset size and number of hash functions used in the filter are dynamically calculated based on [specific formulas](https://en.wikipedia.org/wiki/Bloom_filter#Optimal_number_of_hash_functions)

* Hash functions from [xxHash package](https://pkg.go.dev/github.com/cespare/xxhash/v2@v2.3.0)

* The filter updates with every Set request and resets after flushing.

 
